### PR TITLE
[BUGFIX] Ne pas afficher le clavier sur tout l'écran

### DIFF
--- a/components/EnterMessage.jsx
+++ b/components/EnterMessage.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { View, TextInput, TouchableOpacity, StyleSheet } from "react-native";
+import { View, TextInput, TouchableOpacity, StyleSheet, KeyboardAvoidingView, Platform } from "react-native";
 import { Ionicons } from '@expo/vector-icons';
 
 export default function EnterMessage({ onSendData }) {
@@ -15,7 +15,11 @@ export default function EnterMessage({ onSendData }) {
     }
 
     return (
-        <View style={styles.container}>
+        <KeyboardAvoidingView
+            style={styles.container}
+            behavior={Platform.OS === "ios" ? "padding" : "height"}
+            keyboardVerticalOffset={90}  // Ajustez cette valeur selon la hauteur de votre interface
+        >
             <TextInput
                 style={styles.input}
                 value={textMessage}
@@ -33,7 +37,7 @@ export default function EnterMessage({ onSendData }) {
             >
                 <Ionicons name="send" size={24} color={textMessage ? "#007AFF" : "#999"} />
             </TouchableOpacity>
-        </View>
+        </KeyboardAvoidingView>
     );
 }
 


### PR DESCRIPTION
## Problème
Lorsqu'on affichait le clavier, le bouton pour envoyer le message disparaissait.

## Solution
Utiliser une autre balise que View: KeyboardAvoidingView.

## Pour tester
- Se placer sur la branche après avoir commit et push ses modifications,
- Lancer le projet,
- Vérifier que le clavier s'affiche sans masquer le reste.